### PR TITLE
Set github workspace as safe in git

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,8 @@ EOF
 chmod 0600 ~/.gem/credentials
 set -x
 
+git config --global --add safe.directory "$(pwd)"
+
 work_directory="${WORKDIR:-.}"
 cd $work_directory
 


### PR DESCRIPTION
This check is protecting us from something that's impossible in GH Actions.

See:

https://github.com/actions/runner-images/issues/6775#issuecomment-1420586459